### PR TITLE
Added @objc for Objective C syntax completion

### DIFF
--- a/Pod/Classes/SWSegmentedControl.swift
+++ b/Pod/Classes/SWSegmentedControl.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @IBDesignable
-public class SWSegmentedControl: UIControl {
+@objc public class SWSegmentedControl: UIControl {
     
     private var selectionIndicatorView: UIView!
     private var buttons: [UIButton]?


### PR DESCRIPTION
Without `@objc` it will still work on Objective C it just won't be able to provide auto completion
